### PR TITLE
update geotrellis benchmark to compile against current geotrellis-spark

### DIFF
--- a/geotiff/src/main/scala/geotrellis/benchmark/Main.scala
+++ b/geotiff/src/main/scala/geotrellis/benchmark/Main.scala
@@ -72,11 +72,13 @@ trait GeoTiffReadBenchmark extends SimpleBenchmark {
 
   @inline
   final def readNative(path: String) =
-    geotrellis.raster.io.geotiff.reader.GeoTiffReader.read(path)
+    geotrellis.raster.io.geotiff.reader.GeoTiffReader.readMultiBand(path)
+    // geotrellis.raster.io.geotiff.reader.GeoTiffReader.read(path)
 
   @inline
   final def readGeoTools(path: String) =
-    geotrellis.geotools.GeoTiffReader.read(path)
+    geotrellis.raster.io.geotiff.reader.GeoTiffReader.readMultiBand(path)
+    // geotrellis.geotools.GeoTiffReader.read(path)
 }
 
 object ReadLargeUncompressed extends BenchmarkRunner(classOf[ReadLargeUncompressed])
@@ -240,7 +242,7 @@ object RasterReadProfile {
     var i = 1
     while(true) {
       println(s"Reading $i...")
-      val x = geotrellis.raster.io.geotiff.reader.GeoTiffReader.read(path).bands.head
+      val x = geotrellis.raster.io.geotiff.reader.GeoTiffReader.readMultiBand(path).tile.bandCount
       println(s"  got $x")
       i += 1
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,6 +102,8 @@ object BenchmarkBuild extends Build {
       scalaVersion := Version.scala,
 
       libraryDependencies ++= Seq(
+        "com.azavea.geotrellis" %% "geotrellis-raster" % Version.geotrellis,
+        "com.azavea.geotrellis" %% "geotrellis-gdal" % Version.geotrellis,
         "com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis,
         "com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT" from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar",
         "org.apache.spark" %% "spark-core" % Version.spark % "provided",
@@ -137,7 +139,8 @@ object BenchmarkBuild extends Build {
         "com.google.code.java-allocation-instrumenter" % "java-allocation-instrumenter" % "2.0",
         "com.google.code.gson" % "gson" % "1.7.1",
         "com.azavea.geotrellis" %% "geotrellis-gdal" % Version.geotrellis,
-        "com.azavea.geotrellis" %% "geotrellis-geotools" % Version.geotrellis
+        "com.azavea.geotrellis" %% "geotrellis-geotools" % Version.geotrellis,
+        "com.azavea.geotrellis" %% "geotrellis-raster" % Version.geotrellis
       ),
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/spark/src/main/scala/geotrellis/cmd/Benchmark.scala
+++ b/spark/src/main/scala/geotrellis/cmd/Benchmark.scala
@@ -91,12 +91,13 @@ object Benchmark extends ArgMain[BenchmarkArgs] with LazyLogging {
     polygon: Polygon,
     name: String
   ): RasterRDD[SpaceTimeKey] = {
-    val lmd = catalog.accumuloAttributeStore.read[AccumuloLayerMetaData](id, "metadata")
+    val lmd = catalog.attributeStore.read[AccumuloLayerMetaData](id, "metadata")
     val rmd = lmd.rasterMetaData
     println(s"getRDD RMD: $rmd")
     val bounds = rmd.mapTransform(polygon.envelope)
     println(s"getRDD GridBounds: $bounds")
-    val rdd = catalog.reader[SpaceTimeKey].read(id, FilterSet(SpaceFilter[SpaceTimeKey](bounds)))
+    // val rdd = catalog.read[SpaceTimeKey].read(id, FilterSet(SpaceFilter[SpaceTimeKey](bounds)))
+    val rdd = catalog.query[SpaceTimeKey](id).where(Intersects(bounds)).toRDD
     rdd.setName(name)
     rdd
   }


### PR DESCRIPTION
update geotrellis benchmark to compile against current geotrellis master,

i.e. remove FilterSet API reference, and geotiffReader now lives in raster
